### PR TITLE
feat: only run store function once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,19 @@ import { compose } from 'redux'
 
 const createDynamicMiddlewares = () => {
   let allDynamicMiddlewares = []
+  let allApplyedDynamicMiddlewares = []
+  let store
 
-  const enhancer = store => next => (action) => {
-    const chain = allDynamicMiddlewares.map(middleware => middleware(store))
-
-    return compose(...chain)(next)(action)
+  const enhancer = (_store) => {
+    store = _store
+    return next => (action) => {
+      return compose(...allApplyedDynamicMiddlewares)(next)(action)
+    }
   }
 
   const addMiddleware = (...middlewares) => {
-    allDynamicMiddlewares = [...allDynamicMiddlewares, ...middlewares]
+    allApplyedDynamicMiddlewares.push(...middlewares.map(middleware => middleware(store)))
+    allDynamicMiddlewares.push(...middlewares)
   }
 
   const removeMiddleware = (middleware) => {
@@ -24,9 +28,12 @@ const createDynamicMiddlewares = () => {
     }
 
     allDynamicMiddlewares = allDynamicMiddlewares.filter((_, mdwIndex) => mdwIndex !== index)
+    allApplyedDynamicMiddlewares = allApplyedDynamicMiddlewares
+      .filter((_, mdwIndex) => mdwIndex !== index)
   }
 
   const resetMiddlewares = () => {
+    allApplyedDynamicMiddlewares = []
     allDynamicMiddlewares = []
   }
 


### PR DESCRIPTION
A redux middleware should only run the `(store) =>` function once :)

I'm saving the store in a local variable and directly adding it when you run `addMiddleware` so we don't have to apply it each time the enhancer is run. Also keeping `allDynamicMiddlewares` variable to be able to find and remove middleware.

All tests are passing.